### PR TITLE
Added support for the alternate {.mermaid param=1 ...} syntax.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports.activate = () => {
         extendMarkdownIt(md) {
             const highlight = md.options.highlight;
             md.options.highlight = (code, lang) => {
-                if (lang && lang.toLowerCase() === 'mermaid') {
+                if (lang && (lang.toLowerCase() === 'mermaid' || lang.toLowerCase() === '{.mermaid')) {
                     return `<div class="mermaid">${code}</div>`;
                 }
                 return highlight(code, lang);


### PR DESCRIPTION
Hi,

 Re. issue #11 :

 I've added a small fix to support the alternate fenced code syntax.

 The overlying MarkdownIt should probably add support for it and pass the parameters downstream, but for now, this fix will let people preview diagrams with the alternate syntax.