### PR TITLE
Fix: Class annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ module.exports.activate = () => {
         extendMarkdownIt(md) {
             const highlight = md.options.highlight;
             md.options.highlight = (code, lang) => {
+                /* Class annotation doesn't work
+                https://github.com/mjbvz/vscode-markdown-mermaid/issues/39 */
+                if (code.includes("classDiagram")) {
+                    code = code.replace(/<<[A-Za-z].*>>/g, "");
+                }
+
                 if (lang && lang.match(/\bmermaid\b/i)) {
                     return `<div class="mermaid">${code}</div>`;
                 }


### PR DESCRIPTION
## Expected

[Annotations on classes](https://mermaidjs.github.io/#/classDiagram?id=annotations-on-classes) should work.

## Actual

When annotation starts from alphabetic character, the diagram becomes blank.

## Solution

Selectively remove the misbehaving annotations.

### Reasoning

Currently, if you want to use class diagrams with annotations, you have to modify the mermaid source, which user should not be doing.

This PR does not fix the bug. It is a workaround to allow the user to use unmodified mermaid source, while the faulty annotations would not be displayed.

### Tests

I have manually tested this PR with all the examples on [mermaid](https://mermaidjs.github.io/#/README) and [Class diagrams](https://mermaidjs.github.io/#/classDiagram) pages.

## Reference

#39 - Class annotation doesn't work