### PR TITLE
Fix for ::: block rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ module.exports.activate = () => {
         extendMarkdownIt(md) {
             md.use(require('markdown-it-container'), pluginKeyword, {
                 anyClass: true,
-                validate: () => true,
+                validate: (info) => {
+                    return info.trim() === pluginKeyword;
+                },
 
                 render: (tokens, idx) => {
                     const token = tokens[idx];


### PR DESCRIPTION
There were a couple issues with the previous implementation of `:::` block rendering.
- Webpack needed an extra entry point so it wouldn't tree-shake `markdown-it-container` away completely
- The previous logic was not producing correct input syntax (not sure when this was broken).
- There was the potential to clobber tokens outside the `:::` open/close pair due to the use of .entries(), which has been cleaned up and optimized a bit.
- The container was catching all `:::` blocks, not just mermaid ones (#93)

Fixes #83
Fixes #94