### PR TITLE
do not remove token content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export function activate() {
                             // Clear these out so markdown-it doesn't try to render them
                             value.tag = '';
                             value.type = tokenTypeInline;
-                            value.content = '';
+                            // Code can be triggered multiple times, even if tokens are not updated (eg. on editor losing and regaining focus). Content must be preserved, so src can be realculated in such instances.
+                            //value.content = ''; 
                             value.children = empty;
                         }
                     }


### PR DESCRIPTION
Hey.

I also had problems described in #103 and looked at the code execution. 

I have noticed, that for some reason render function executes multiple times (probably when leaving window?). The second time around all content is empty, as it is removed/emptied in first pass. When you start editing file again, tokens are recreated and graph is shown.

not removing token.content seems to fix the behavior.

