### PR TITLE
fix: narrowing the display width of the screen causes unnecessary margins at the top and bottom.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "markdown.previewScripts": [
       "./page.bundle.js"
     ],
+    "markdown.previewStyles": [
+      "./page.css"
+    ],
     "markdown.markdownItPlugins": true
   },
   "dependencies": {

--- a/page.css
+++ b/page.css
@@ -1,0 +1,3 @@
+.mermaid > svg {
+  height: auto;
+}


### PR DESCRIPTION
Hi, I use this extension frequently. Thank you.

When the diagram (SVG element) is large, narrowing the width of the display screen results in extra white space at the top and bottom.

This happens even when I import external CSS... (markdown.styles)
https://cdn.jsdelivr.net/npm/github-markdown-css@3.0.1/github-markdown.min.css


I've been dealing with this by applying the following styles
How about handling this by default?
```
<style>
svg {
  height: 100%;
}
</style>
```