### PR TITLE
feat: Upgrade mermaid version to 9.1.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ graph TD;
 
 ## Mermaid
 
-Currently supports Mermaid version 9.1.1.
+Currently supports Mermaid version 9.1.2.
 
 ## Add custom CSS support
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.15.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^2.1.1",
-    "mermaid": "^9.1.1",
+    "mermaid": "^9.1.2",
     "mini-css-extract-plugin": "^2.2.2",
     "style-loader": "^3.2.1",
     "terser-webpack-plugin": "^2.3.8",


### PR DESCRIPTION
Mermaid version is upgraded to 9.1.2.
Mermaid 9.1.2 has an experimental support for C4 diagrams that might be handy.