### PR TITLE
Better syntax error reporting

### DIFF
--- a/page.js
+++ b/page.js
@@ -9,13 +9,19 @@ function init() {
             : 'default'
     });
 
-    // Delete existing mermaid outputs
-    for (const possibleMermaidErrorOut of document.getElementsByTagName('svg')) {
-        const parent = possibleMermaidErrorOut.parentElement;
-        if (parent && parent.id.startsWith('dmermaid')) {
-            parent.remove();
+    function processMermaidErrorOuts(processCallback) {
+        for (const possibleMermaidErrorOut of document.getElementsByTagName('svg')) {
+            const parent = possibleMermaidErrorOut.parentElement;
+            if (parent && parent.id.startsWith('dmermaid')) {
+                processCallback(parent);
+            }
         }
     }
+
+    // Delete existing mermaid outputs
+    processMermaidErrorOuts((mermaidErrorOut) => {
+        mermaidErrorOut.remove();
+    });
 
     let i = 0;
     for (const mermaidContainer of document.getElementsByClassName('mermaid')) {
@@ -27,9 +33,22 @@ function init() {
         mermaidContainer.innerHTML = '';
         mermaidContainer.appendChild(out);
 
-        mermaid.render(id, source, (out) => {
-            mermaidContainer.innerHTML = out;
-        });
+        try {
+            mermaid.render(id, source, (out) => {
+                mermaidContainer.innerHTML = out;
+            });
+        } catch (error) {
+            const errorMessageNode = document.createElement('pre');
+
+            errorMessageNode.innerText = error.message;
+
+            processMermaidErrorOuts((mermaidErrorOut) => {
+                mermaidErrorOut.appendChild(errorMessageNode);
+            });
+
+            // don't break standart mermaid flow
+            throw error;
+        }
     }
 }
 


### PR DESCRIPTION
Hi! )

I tried to add error display to the extension:
https://github.com/mjbvz/vscode-markdown-mermaid/issues/129

**Some details:**

I managed to override the `parseError` method via `mermaid.setParseErrorHandler` / `mermaid.parseError`, but it is not working during the "bomb". As far as I understand, `parseError` calls only inside [mermaid.init](https://github.com/mermaid-js/mermaid/blob/release/9.1.2/src/mermaid.js#L39) or [mermaidAPI.parse](https://github.com/mermaid-js/mermaid/blob/9.1.2/src/mermaidAPI.js#L177), but the "bomb" explodes during the [mermaid.render](https://github.com/mjbvz/vscode-markdown-mermaid/blob/master/page.js#L30) in the extension (by error throwing).

**What I did:**

I took the path of least resistance and wrapped `mermaid.render` in try..catch for error catching. I tried not to break the standard behavior of the mermaid library, just added the error message to the bomb.

**It looks like this now:**

<img width="700" alt="demo1" src="https://user-images.githubusercontent.com/23284240/180446328-83f9b8f0-1296-41a4-92d8-ef1fcf54e1e7.png">
<img width="700" alt="demo2" src="https://user-images.githubusercontent.com/23284240/180446361-71955595-5819-4c62-ab04-473e4a6dedb2.png">
<img width="700" alt="demo3" src="https://user-images.githubusercontent.com/23284240/180446369-0d767111-0fd4-468d-80bd-b8c0ef1e4b21.png">

Thanks!