### PR TITLE
fix: support keyword`graph`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 
             const highlight = md.options.highlight;
             md.options.highlight = (code: string, lang: string) => {
-                if (lang && lang.match(/\bmermaid\b/i)) {
+                if (lang && lang.match(/\b(mermaid)|(graph)\b/i)) {
                     return `<pre style="all:unset;"><div class="${pluginKeyword}">${preProcess(code)}</div></pre>`;
                 }
                 return highlight(code, lang);


### PR DESCRIPTION
Mark `graph` as code block, too.