### PR TITLE
Update to Mermaid version 9.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds [Mermaid](https://mermaid-js.github.io/mermaid/#/) diagram and flowchart su
 
 ![A mermaid diagram in VS Code's built-in markdown preview](https://github.com/mjbvz/vscode-markdown-mermaid/raw/master/docs/example.png)
 
-Currently supports Mermaid version 9.2.2.
+Currently supports Mermaid version 9.3.0.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/vscode-notebook-renderer": "^1.72.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^2.1.1",
-    "mermaid": "^9.2.2",
+    "mermaid": "^9.3.0",
     "mini-css-extract-plugin": "^2.2.2",
     "style-loader": "^3.2.1",
     "terser-webpack-plugin": "^5.3.6",


### PR DESCRIPTION
Mermaid 9.3.0 is out, with lots of improvements, including title support for all diagrams!

Bumping the version here to 9.3.0 so it supports the latest and greatest Mermaid features. I think this is the only change required?

It will close https://github.com/mjbvz/vscode-markdown-mermaid/issues/164.