### PR TITLE
Possible fix for parse failures with sequence diagrams

### DIFF
--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -58,7 +58,8 @@ function preProcess(source: string): string {
     return source
         .replace(/\</g, '&lt;')
         .replace(/\>/g, '&gt;')
-        .trim();
+        .replace(/\n+$/,'')
+        .trimStart();
 }
 
 function escapeRegExp(string: string): string {


### PR DESCRIPTION
Fix for an issue where sequence diagrams that end with a Message that has no text, just whitespace. The markdown parses in Github, but fails in VS Code preview pane. The `trim()` is removing the whitespace needed by Mermaid to parse the Message line and render the diagram. I have replaced it with a trim form the start of the string and just replacing trailing newlines only. I tried also just removing the `trim()` and could not see any issues but did not test all the other diagram types. 

MD file I used to reproduce the error:

## Use Cases 

### Sequence Diagram with text on last line

```mermaid
sequenceDiagram
    A->>B: This diagram parses
    B-->>A: text on last line
```

### Sequence Diagram with spaces on last line
```mermaid
sequenceDiagram
    A->>B: This diagram fails with spaces on last line
    B-->>A: 
```

### Everything below the parse failure does not render as diagram
```mermaid
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
```
