### PR TITLE
Upgrade css-loader to resolve conflict with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@types/vscode": "^1.72.0",
     "@types/vscode-notebook-renderer": "^1.72.0",
     "babel-loader": "^8.2.2",
-    "css-loader": "^2.1.1",
+    "css-loader": "^6.7.3",
     "mermaid": "^9.3.0",
     "mini-css-extract-plugin": "^2.2.2",
     "style-loader": "^3.2.1",


### PR DESCRIPTION
`css-loader` of version 2.1.1 required `webpack` version 4. This caused a conflict with `webpack` version 5 used by the project. Upgrading `css-loader` to most recent version 6.7.3 resolves it.

Not including `package-lock.json` changes as per previous request.
