### PR TITLE
fix: handle errors appended to body by mermaid

### DIFF
--- a/markdownPreview/mermaid.ts
+++ b/markdownPreview/mermaid.ts
@@ -23,11 +23,7 @@ export function renderMermaidBlocksInElement(root: HTMLElement) {
     function renderMermaidElement(mermaidContainer: Element) {
         const id = `mermaid-${crypto.randomUUID()}`;
         const source = mermaidContainer.textContent ?? '';
-
-        const out = document.createElement('div');
-        out.id = id;
         mermaidContainer.innerHTML = '';
-        mermaidContainer.appendChild(out);
 
         try {
             mermaid.mermaidAPI.reset();
@@ -37,6 +33,13 @@ export function renderMermaidBlocksInElement(root: HTMLElement) {
         } catch (error) {
             if (error instanceof Error) {
                 const errorMessageNode = document.createElement('pre');
+
+                // If error svg was appended to the body move it to the container and clean up wrapper element
+                const errSvg = document.querySelector(`svg#${id}`);
+                if (errSvg && errSvg.parentElement?.id === `d${id}`) {
+                    errSvg.parentElement.remove();
+                    mermaidContainer.prepend(errSvg);
+                }
 
                 errorMessageNode.innerText = error.message;
 


### PR DESCRIPTION
## Overview
- Removes unused `out` div.
- If the svg appended by mermaid is still on the page then move it to the correct location and cleanup the wrapper.

For some errors the div + svg added by mermaid is not cleaned up and an error is thrown [here](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/mermaidAPI.ts#L505). This leads to a list of permanent error messages that grows until the preview is refreshed.


## Repro Steps
Open a markdown document with the following content:
````markdown
```mermaid
flowchart

```
````

Add and remove newlines and the error svgs will grow. There is also no error info.

<img width="738" alt="image" src="https://user-images.githubusercontent.com/10948202/222986263-e4a3bb9a-bb14-4b74-b975-c0bd796f5d68.png">
<img width="446" alt="image" src="https://user-images.githubusercontent.com/10948202/222986315-a7f2f8ee-7ff6-4941-a0b5-c0f8f6971dac.png">


## After fix
Errors should not grow, and fully disappear when resolved.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/10948202/222986362-9ec9a9de-f094-41ef-8eee-bd827a684da8.png">

Thank you for putting this extension together! It's been super useful.