### PR TITLE
Upgrade mermaid to the latest version 10.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds [Mermaid](https://mermaid-js.github.io/mermaid/#/) diagram and flowchart su
 
 ![A mermaid diagram in VS Code's built-in markdown preview](https://github.com/mjbvz/vscode-markdown-mermaid/raw/master/docs/example.png)
 
-Currently supports Mermaid version 9.3.0.
+Currently supports Mermaid version 10.0.2.
 
 ## Usage
 

--- a/markdownPreview/mermaid.ts
+++ b/markdownPreview/mermaid.ts
@@ -9,7 +9,7 @@ function processMermaidErrorOuts(processCallback: (element: HTMLElement) => void
     }
 }
 
-export function renderMermaidBlocksInElement(root: HTMLElement) {
+export async function renderMermaidBlocksInElement(root: HTMLElement) {
 
     // Delete existing mermaid outputs
     processMermaidErrorOuts((mermaidErrorOut) => {
@@ -17,10 +17,10 @@ export function renderMermaidBlocksInElement(root: HTMLElement) {
     });
 
     for (const mermaidContainer of root.getElementsByClassName('mermaid') ?? []) {
-        renderMermaidElement(mermaidContainer);
+        await renderMermaidElement(mermaidContainer);
     }
 
-    function renderMermaidElement(mermaidContainer: Element) {
+    async function renderMermaidElement(mermaidContainer: Element) {
         const id = `mermaid-${crypto.randomUUID()}`;
         const source = mermaidContainer.textContent ?? '';
 
@@ -31,9 +31,9 @@ export function renderMermaidBlocksInElement(root: HTMLElement) {
 
         try {
             mermaid.mermaidAPI.reset();
-            mermaid.render(id, source, (out) => {
-                mermaidContainer.innerHTML = out;
-            });
+            const {svg, bindFunctions} = await mermaid.render(id, source, mermaidContainer);
+            mermaidContainer.innerHTML = svg;
+            bindFunctions?.(mermaidContainer);
         } catch (error) {
             if (error instanceof Error) {
                 const errorMessageNode = document.createElement('pre');

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/vscode-notebook-renderer": "^1.72.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^6.7.3",
-    "mermaid": "^9.3.0",
+    "mermaid": "^10.0.2",
     "mini-css-extract-plugin": "^2.2.2",
     "npm-run-all": "^4.1.5",
     "style-loader": "^3.2.1",


### PR DESCRIPTION
Mermaid version 10.0.2 is the latest, but it has some breaking API changes.

I had to change the `mermaid.render` call as it no longer accepts a callback.
see https://github.com/mermaid-js/mermaid/blob/master/CHANGELOG.md#1000

N.B. I tested the rendering and it works for correct graph, but it does not render parsing errors.

I see the following error in DevTools console whenever I try to render broken diagram:
```
 mermaid.core.mjs:202 36.409 : ERROR :  Error parsing Error: Diagram error not found.
    at Wt (utils-d5eeff82.js:2210:9)
    at new Nt (mermaidAPI-0716c7c2.js:384:21)
    at Object.render (mermaidAPI-0716c7c2.js:659:12)
(anonymous) @ mermaid.core.mjs:202
mermaid.core.mjs:165 36.409 : ERROR :  Error executing queue Error: Diagram error not found.
    at Wt (utils-d5eeff82.js:2210:9)
    at new Nt (mermaidAPI-0716c7c2.js:384:21)
    at Object.render (mermaidAPI-0716c7c2.js:659:12)
f @ mermaid.core.mjs:165
utils-d5eeff82.js:2210 Uncaught (in promise) Error: Diagram error not found.
    at Wt (utils-d5eeff82.js:2210:9)
    at new Nt (mermaidAPI-0716c7c2.js:384:21)
    at Object.render (mermaidAPI-0716c7c2.js:659:12)
```

This can be traced to this code in [`Diagram.ts`](https://github.com/mermaid-js/mermaid/blob/6b5221e465a36b895bb5c43710bd9229b37e40dc/packages/mermaid/src/Diagram.ts#L30) and [`diagramAPI.ts`](https://github.com/mermaid-js/mermaid/blob/6b251de227d999af7371e4928445193fe3a6de54/packages/mermaid/src/diagram-api/diagramAPI.ts#L72)


Not sure if this is a bug in Mermaid or if I'm calling it incorrectly. Any help would be appreciated.