### PR TITLE
feat(ci): add git workflow for vsix file build and release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build vsix file
+
+on:
+  push:
+    tags:
+      - "*"
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+    - run: npm install
+    - run: npm install -g vsce
+    - run: |
+        version=$(node -p "require('./package.json').version")
+        echo "VERSION=${version}" >> $GITHUB_ENV
+    - run: vsce package
+    - name: Get Changelog
+      id: get-changelog
+      run: |
+        awk 'BEGIN{block=""; lastBlock=""} /^##/{if(block!=""){lastBlock=block; block=""}} {block=block?block ORS $0:$0} END{print lastBlock}' CHANGELOG.md  > .changelog.md
+    - name: create release by gh
+      id: create_release
+      run: |
+        gh release create v${{ env.VERSION }} -t v${{ env.VERSION }} -F .changelog.md ./*.vsix 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.log
 .DS_Store
 dist*
+
+**.vsix 


### PR DESCRIPTION
### Title: 
Implement GitHub Actions for Automatic .vsix File Creation and Release

### Description:

This pull request introduces a new GitHub Actions workflow dedicated to enhancing our automation capabilities. With this update, whenever new tags are pushed to the repository, a GitHub Actions workflow is triggered to automatically build `.vsix` files. Upon successful build completion, it then automatically creates a GitHub release and attaches the built `.vsix` file to it. This automation streamlines the release process, making it more efficient and error-proof.

Additionally, I've updated the `.gitignore` file to exclude `.vsix` files from being tracked in the repository. This ensures that our repository remains clean and only contains source code and necessary project files, rather than compiled artifacts.

#### Key Changes:

- **GitHub Actions Workflow**: A new workflow has been added to `.github/workflows` that is responsible for building `.vsix` files upon detecting new tags. This workflow utilizes the GitHub Actions runner's capabilities to automate the build and release process efficiently.
  
- **.gitignore Update**: Updated the `.gitignore` file to exclude `.vsix` files. This prevents accidentally committing compiled artifacts to the repository, keeping our source control cleaner and more manageable.



Looking forward to your feedback and suggestions!

🚀