### PR TITLE
Avoid premature interpretation of HTML characters (#273)

### DIFF
--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -141,6 +141,7 @@ export function extendMarkdownItWithMermaid(md: MarkdownIt, config: { languageId
 
 function preProcess(source: string): string {
     return source
+        .replace(/&/g, '&amp;')
         .replace(/\</g, '&lt;')
         .replace(/\>/g, '&gt;')
         .replace(/\n+$/, '')


### PR DESCRIPTION
### Why

Resolves Issue #273, allowing for the standard use of parentheses within the texts of a graph, using HTML characters (e.g., `&lpar;`).

### How

There's already a `preProcess(…)` function used to encode `<` and `>` prior to inject the mermaid source code into a DOM element whose `.textContent` would then be read to feed the mermaid renderer. I just encode `&` too (so that `&lpar;` is encoded as `&amp;lpar;` and is not interpreted as `(` prior to feeding the renderer, but as the intended `&lpar;`).