### PR TITLE
feat: add iconify logos

### DIFF
--- a/markdownPreview/index.ts
+++ b/markdownPreview/index.ts
@@ -1,18 +1,11 @@
 import mermaid, { MermaidConfig } from 'mermaid';
 import { renderMermaidBlocksInElement } from './mermaid';
-import * as logos from '@iconify-json/logos';
+import { registerIconPacks } from '../src/mermaid';
 
 function init() { 
     const configSpan = document.getElementById('markdown-mermaid');
     const darkModeTheme = configSpan?.dataset.darkModeTheme;
     const lightModeTheme = configSpan?.dataset.lightModeTheme;
-  
-    mermaid.registerIconPacks([
-      {
-        name: 'logos',
-        loader: () => Promise.resolve(logos.icons),
-      },
-    ]);
 
     const config = {
         startOnLoad: false,
@@ -20,6 +13,8 @@ function init() {
             ? darkModeTheme ?? 'dark'
             : lightModeTheme ?? 'default' ) as MermaidConfig['theme'],
     };
+
+    registerIconPacks();
     mermaid.initialize(config);
 
     renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {

--- a/markdownPreview/index.ts
+++ b/markdownPreview/index.ts
@@ -1,10 +1,18 @@
 import mermaid, { MermaidConfig } from 'mermaid';
 import { renderMermaidBlocksInElement } from './mermaid';
+import * as logos from '@iconify-json/logos';
 
-function init() {
+function init() { 
     const configSpan = document.getElementById('markdown-mermaid');
     const darkModeTheme = configSpan?.dataset.darkModeTheme;
     const lightModeTheme = configSpan?.dataset.lightModeTheme;
+  
+    mermaid.registerIconPacks([
+      {
+        name: 'logos',
+        loader: () => Promise.resolve(logos.icons),
+      },
+    ]);
 
     const config = {
         startOnLoad: false,

--- a/markdownPreview/index.ts
+++ b/markdownPreview/index.ts
@@ -1,6 +1,7 @@
 import mermaid, { MermaidConfig } from 'mermaid';
 import { renderMermaidBlocksInElement } from './mermaid';
 import { registerIconPacks } from '../src/mermaid';
+import { iconPackConfig } from '../src/iconPackConfig';
 
 function init() { 
     const configSpan = document.getElementById('markdown-mermaid');
@@ -14,7 +15,7 @@ function init() {
             : lightModeTheme ?? 'default' ) as MermaidConfig['theme'],
     };
 
-    registerIconPacks();
+    registerIconPacks(iconPackConfig);
     mermaid.initialize(config);
 
     renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {

--- a/notebook/index.ts
+++ b/notebook/index.ts
@@ -4,6 +4,7 @@ import { registerIconPacks } from '../src/mermaid';
 import type { RendererContext } from 'vscode-notebook-renderer';
 import { renderMermaidBlocksInElement } from '../markdownPreview/mermaid';
 import { extendMarkdownItWithMermaid } from '../src/mermaid';
+import { iconPackConfig } from '../src/iconPackConfig';
 
 interface MarkdownItRenderer {
     extendMarkdownIt(fn: (md: MarkdownIt) => void): void;
@@ -17,10 +18,10 @@ export async function activate(ctx: RendererContext<void>) {
 
     const config = {
         startOnLoad: false,
-        theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default'
+        theme: (document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default') as 'default' | 'dark',
     };
     
-    registerIconPacks();
+    registerIconPacks(iconPackConfig);
     mermaid.initialize(config);
 
     markdownItRenderer.extendMarkdownIt((md: MarkdownIt) => {

--- a/notebook/index.ts
+++ b/notebook/index.ts
@@ -1,5 +1,6 @@
 import type * as MarkdownIt from 'markdown-it';
 import mermaid from 'mermaid';
+import { registerIconPacks } from '../src/mermaid';
 import type { RendererContext } from 'vscode-notebook-renderer';
 import { renderMermaidBlocksInElement } from '../markdownPreview/mermaid';
 import { extendMarkdownItWithMermaid } from '../src/mermaid';
@@ -18,6 +19,8 @@ export async function activate(ctx: RendererContext<void>) {
         startOnLoad: false,
         theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default'
     };
+    
+    registerIconPacks();
     mermaid.initialize(config);
 
     markdownItRenderer.extendMarkdownIt((md: MarkdownIt) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
-        "@iconify-json/logos": "^1.2.0"
+        "@iconify-json/logos": "^1.2.0",
+        "@iconify-json/mdi": "^1.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.15.0",
         "@types/markdown-it": "^14.1.0",
         "@types/vscode": "^1.72.0",
         "@types/vscode-notebook-renderer": "^1.72.0",
+        "@types/webpack-env": "^1.18.5",
         "babel-loader": "^8.2.2",
         "css-loader": "^6.7.3",
         "mermaid": "^11.1.0",
@@ -426,11 +428,19 @@
         "@iconify/types": "*"
       }
     },
+    "node_modules/@iconify-json/mdi": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.0.tgz",
+      "integrity": "sha512-E9/3l5Syg3wfuarorFodhn4s8YorxhH3U3U20LaNBNiqw1kFNIDWhF6HymuzAD35k7RH0OBasJ+ZUyFtVVV6eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
@@ -571,6 +581,13 @@
       "resolved": "https://registry.npmjs.org/@types/vscode-notebook-renderer/-/vscode-notebook-renderer-1.72.3.tgz",
       "integrity": "sha512-MfmEI3A2McbUV2WaijoTgLOAs9chwHN4WmqOedl3jdtlbzJBWIQ9ZFmQdzPa3lYr5j8DJhRg3KB5AIM/BBfg9Q==",
       "dev": true
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.5.tgz",
+      "integrity": "sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "markdown-mermaid",
       "version": "1.23.1",
       "license": "MIT",
+      "dependencies": {
+        "@iconify-json/logos": "^1.2.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.15.0",
         "@types/markdown-it": "^14.1.0",
@@ -413,6 +416,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@iconify-json/logos": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.0.tgz",
+      "integrity": "sha512-VkU9QSqeZR2guWbecdqkcoZEAJfgJJTUm6QAsypuZQ7Cve6zy39wOXDjp2H31I8QyQy4O3Cz96+pNji6UQFg4w==",
+      "dependencies": {
+        "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/types": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
       }
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "@iconify-json/logos": "^1.2.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@types/markdown-it": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -84,13 +84,15 @@
     }
   },
   "dependencies": {
-    "@iconify-json/logos": "^1.2.0"
+    "@iconify-json/logos": "^1.2.0",
+    "@iconify-json/mdi": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@types/markdown-it": "^14.1.0",
     "@types/vscode": "^1.72.0",
     "@types/vscode-notebook-renderer": "^1.72.0",
+    "@types/webpack-env": "^1.18.5",
     "babel-loader": "^8.2.2",
     "css-loader": "^6.7.3",
     "mermaid": "^11.1.0",

--- a/src/iconPackConfig.ts
+++ b/src/iconPackConfig.ts
@@ -1,0 +1,16 @@
+export const iconPackConfig = [
+    {
+      prefix: 'logos',
+      pack: '@iconify-json/logos', 
+    },
+    {
+      prefix: 'mdi',
+      pack: '@iconify-json/mdi',
+    }
+  ];
+  
+  export const requireIconPack = require.context(
+    '@iconify-json', 
+    true,            
+    /^\.\/(logos|mdi)$/, 
+  );

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -1,5 +1,6 @@
 import type MarkdownIt from 'markdown-it';
 import mermaid from 'mermaid';
+import { requireIconPack } from './iconPackConfig';
 
 const mermaidLanguageId = 'mermaid';
 const containerTokenName = 'mermaidContainer';
@@ -153,13 +154,19 @@ function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+export function registerIconPacks(config: Array<{ prefix?: string; pack: string }>) {
+    const iconPacks = config.map((iconPack) => ({
+        name: iconPack.prefix || '',
+        loader: () => {
+        try {
+            const module = requireIconPack(`./${iconPack.pack.replace('@iconify-json/', '')}`);
+            return module.icons || {}; 
+        } catch (error) {
+            console.error(`Failed to load icon pack: ${iconPack.pack}`, error);
+            return {}; 
+        }
+        },
+    }));
 
-export function registerIconPacks() {
-    mermaid.registerIconPacks([
-        {
-            name: 'logos',
-            loader: () => import('@iconify-json/logos').then((module) => module.icons),
-          },
-    ]);
-
+    mermaid.registerIconPacks(iconPacks);
 }

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -1,4 +1,5 @@
 import type MarkdownIt from 'markdown-it';
+import mermaid from 'mermaid';
 
 const mermaidLanguageId = 'mermaid';
 const containerTokenName = 'mermaidContainer';
@@ -150,4 +151,15 @@ function preProcess(source: string): string {
 
 function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+
+export function registerIconPacks() {
+    mermaid.registerIconPacks([
+        {
+            name: 'logos',
+            loader: () => import('@iconify-json/logos').then((module) => module.icons),
+          },
+    ]);
+
 }


### PR DESCRIPTION
The architecture diagram is now available in mermaid v11.1.0.
However, currently iconify logos cannot be seen in VSCode.
This pull request will allow iconify logos to be used.

Before
<img width="408" alt="スクリーンショット 2024-09-08 1 22 13" src="https://github.com/user-attachments/assets/c0aba25b-7028-46e5-a31d-1712c300b5f8">

after
<img width="408" alt="スクリーンショット 2024-09-08 1 19 40" src="https://github.com/user-attachments/assets/3ae0e49d-c88f-478b-8b34-0d1d24a3094b">