### PR TITLE
Upgrade mermaid version to 11.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds [Mermaid](https://mermaid-js.github.io/mermaid/#/) diagram and flowchart su
 
 ![A mermaid diagram in VS Code's built-in markdown preview](https://github.com/mjbvz/vscode-markdown-mermaid/raw/master/docs/example.png)
 
-Currently supports Mermaid version 11.1.0.
+Currently supports Mermaid version 11.2.0.
 
 ## Usage
 

--- a/notebook/index.ts
+++ b/notebook/index.ts
@@ -1,5 +1,5 @@
 import type * as MarkdownIt from 'markdown-it';
-import mermaid from 'mermaid';
+import mermaid, { MermaidConfig } from 'mermaid';
 import type { RendererContext } from 'vscode-notebook-renderer';
 import { renderMermaidBlocksInElement } from '../markdownPreview/mermaid';
 import { extendMarkdownItWithMermaid } from '../src/mermaid';
@@ -14,7 +14,7 @@ export async function activate(ctx: RendererContext<void>) {
         throw new Error(`Could not load 'vscode.markdown-it-renderer'`);
     }
 
-    const config = {
+    const config: MermaidConfig = {
         startOnLoad: false,
         theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default'
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/vscode-notebook-renderer": "^1.72.0",
         "babel-loader": "^8.2.2",
         "css-loader": "^6.7.3",
-        "mermaid": "^11.1.0",
+        "mermaid": "^11.2.0",
         "mini-css-extract-plugin": "^2.2.2",
         "npm-run-all": "^4.1.5",
         "style-loader": "^3.2.1",
@@ -3078,11 +3078,10 @@
       "dev": true
     },
     "node_modules/mermaid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.1.0.tgz",
-      "integrity": "sha512-ICexrwPRzU1USFcpAdrVVGjCwEajD+iAwu2LVHi59D6VbXmFhwfB9TbCL3sA6NBR1tl5qUjQSAOdc9lOKlXnEw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.2.0.tgz",
+      "integrity": "sha512-ZinOa063lk81lujX8vkINNqmFaNMk1A95Z4kCL7fE6QLAi01CxeiUJVw+tpXU+lAM73utO39G+2PLjxS2GYS/w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.1",
         "@iconify/utils": "^2.1.32",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/vscode-notebook-renderer": "^1.72.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^6.7.3",
-    "mermaid": "^11.1.0",
+    "mermaid": "^11.2.0",
     "mini-css-extract-plugin": "^2.2.2",
     "npm-run-all": "^4.1.5",
     "style-loader": "^3.2.1",


### PR DESCRIPTION
Upgrade mermaid version and add MermaidConfig type to notebook as `vsce package` failed when running locally due to TS error.

Wanted to bump version to at least 11.1.1 as it fixes self-referencing node issue resolved in
https://github.com/mermaid-js/mermaid/pull/5828