### PR TITLE
Fix ELK layouts

### DIFF
--- a/markdownPreview/index.ts
+++ b/markdownPreview/index.ts
@@ -1,5 +1,6 @@
 import mermaid, { MermaidConfig } from 'mermaid';
 import { renderMermaidBlocksInElement } from './mermaid';
+import elkLayouts from '@mermaid-js/layout-elk';
 
 function init() {
     const configSpan = document.getElementById('markdown-mermaid');
@@ -12,6 +13,7 @@ function init() {
             ? darkModeTheme ?? 'dark'
             : lightModeTheme ?? 'default' ) as MermaidConfig['theme'],
     };
+    mermaid.registerLayoutLoaders(elkLayouts);
     mermaid.initialize(config);
 
     renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {

--- a/notebook/index.ts
+++ b/notebook/index.ts
@@ -3,6 +3,7 @@ import mermaid, { MermaidConfig } from 'mermaid';
 import type { RendererContext } from 'vscode-notebook-renderer';
 import { renderMermaidBlocksInElement } from '../markdownPreview/mermaid';
 import { extendMarkdownItWithMermaid } from '../src/mermaid';
+import elkLayouts from '@mermaid-js/layout-elk';
 
 interface MarkdownItRenderer {
     extendMarkdownIt(fn: (md: MarkdownIt) => void): void;
@@ -18,6 +19,7 @@ export async function activate(ctx: RendererContext<void>) {
         startOnLoad: false,
         theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default'
     };
+    mermaid.registerLayoutLoaders(elkLayouts);
     mermaid.initialize(config);
 
     markdownItRenderer.extendMarkdownIt((md: MarkdownIt) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.0",
+        "@mermaid-js/layout-elk": "^0.1.4",
         "@types/markdown-it": "^14.1.0",
         "@types/vscode": "^1.72.0",
         "@types/vscode-notebook-renderer": "^1.72.0",
@@ -494,6 +495,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.1.4.tgz",
+      "integrity": "sha512-t0/1E0/zz8vfSNtvm7iJibx/r7GexRA6/yHWqbkAohUFjUvhpSA3Z2HAhci4BUG04if0DO+zAFCPDuenesPNZg==",
+      "dev": true,
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.0"
       }
     },
     "node_modules/@mermaid-js/parser": {
@@ -1910,6 +1924,12 @@
       "version": "1.4.751",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.751.tgz",
       "integrity": "sha512-2DEPi++qa89SMGRhufWTiLmzqyuGmNF3SK4+PQetW1JKiZdEpF4XQonJXJCzyuYSA6mauiMhbyVhqYAP45Hvfw==",
+      "dev": true
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "dev": true
     },
     "node_modules/emojis-list": {

--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
       }
     }
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.15.0",
+    "@mermaid-js/layout-elk": "^0.1.4",
     "@types/markdown-it": "^14.1.0",
     "@types/vscode": "^1.72.0",
     "@types/vscode-notebook-renderer": "^1.72.0",
@@ -102,6 +102,7 @@
     "webpack-cli": "^5.0.1"
   },
   "scripts": {
+    "vsix": "vsce package",
     "build-preview": "webpack --mode=production --config ./build/markdownPreview.webpack.config.js",
     "build-notebook": "webpack --mode=production --config ./build/notebook.webpack.config.js",
     "compile-ext": "webpack --config ./build/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       }
     }
   },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@mermaid-js/layout-elk": "^0.1.4",
@@ -102,7 +103,6 @@
     "webpack-cli": "^5.0.1"
   },
   "scripts": {
-    "vsix": "vsce package",
     "build-preview": "webpack --mode=production --config ./build/markdownPreview.webpack.config.js",
     "build-notebook": "webpack --mode=production --config ./build/notebook.webpack.config.js",
     "compile-ext": "webpack --config ./build/webpack.config.js",


### PR DESCRIPTION
It looks like in version 11, mermaid separated out ELK into its own library. So in order to do any elk rendering you have to use the new library. I used the docs in [their readme](https://github.com/mermaid-js/mermaid/blob/a07f1f3337915e6f833d655c6af8bfb2cf7cd529/packages/mermaid-layout-elk/README.md) to add that library here.

Here's some examples of the new code and how it renders in my local vscode:

<details>
<summary>Code + Render</summary>

# Mermaid After Updates 

### YAML config

```
---
config:
  logLevel: 1
  layout: elk
  elk:
    mergeEdges: true
    nodePlacementStrategy: SIMPLE
---

flowchart LR
  A --> B
  A --> C
  B --> D
  C --> D
```

### Init Declaration Config

```
%%{ init: { 'flowchart': { 'defaultRenderer': 'elk' } } }%%

flowchart LR
  A --> B
  A --> C
  B --> D
  C --> D
```

### No Config

```
flowchart LR
  A --> B
  A --> C
  B --> D
  C --> D
```

![image](https://github.com/user-attachments/assets/8992212b-2d9a-4957-b1b5-7e6dffcb4a34)


</details>

⚠️ I did **not** test the notebook renderer, since I don't use those. I can remove that bit from the PR if needed, but I assume it works very similarly.
