### PR TITLE
feat: add google official material-symbols icons

### DIFF
--- a/src/shared-mermaid/iconPackConfig.ts
+++ b/src/shared-mermaid/iconPackConfig.ts
@@ -4,6 +4,10 @@ export const iconPackConfig = [
         pack: '@iconify-json/logos',
     },
     {
+        prefix: 'material-symbols',
+        pack: '@iconify-json/material-symbols',
+    },
+    {
         prefix: 'mdi',
         pack: '@iconify-json/mdi',
     }


### PR DESCRIPTION
Add the material-symbols icons published by google. see: https://icones.js.org/collection/material-symbols note the author