### PR TITLE
Add support for configuring the maximum text size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
             "mermaid"
           ],
           "description": "Default languages in markdown."
+        },
+        "markdown-mermaid.maxTextSize": {
+          "order": 3,
+          "type": "number",
+          "default": 50000,
+          "description": "The maximum allowed size of the users text diagram."
         }
       }
     }

--- a/src/markdownPreview/index.ts
+++ b/src/markdownPreview/index.ts
@@ -10,9 +10,11 @@ function init() {
     const configSpan = document.getElementById('markdown-mermaid');
     const darkModeTheme = configSpan?.dataset.darkModeTheme;
     const lightModeTheme = configSpan?.dataset.lightModeTheme;
+    const maxTextSize = configSpan?.dataset.maxTextSize;
 
     const config: MermaidConfig = {
         startOnLoad: false,
+        maxTextSize: maxTextSize ? Number(maxTextSize) : 50000,
         theme: (document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast')
             ? darkModeTheme ?? 'dark'
             : lightModeTheme ?? 'default' ) as MermaidConfig['theme'],

--- a/src/vscode-extension/themeing.ts
+++ b/src/vscode-extension/themeing.ts
@@ -20,9 +20,11 @@ export function injectMermaidTheme(md: MarkdownIt) {
     md.renderer.render = function (...args) {
         const darkModeTheme = sanitizeMermaidTheme(vscode.workspace.getConfiguration(configSection).get('darkModeTheme'));
         const lightModeTheme = sanitizeMermaidTheme(vscode.workspace.getConfiguration(configSection).get('lightModeTheme'));
+        const maxTextSize = vscode.workspace.getConfiguration(configSection).get('maxTextSize') as number;
         return `<span id="${configSection}" aria-hidden="true"
                     data-dark-mode-theme="${darkModeTheme}"
-                    data-light-mode-theme="${lightModeTheme}"></span>
+                    data-light-mode-theme="${lightModeTheme}"
+                    data-max-text-size="${maxTextSize}"></span>
                 ${render.apply(md.renderer, args)}`;
     };
     return md;


### PR DESCRIPTION
Enabled support for rendering Mermaid diagrams exceeding 50,000 characters by introducing a configurable maxTextSize option.

[Issue 258](https://github.com/mjbvz/vscode-markdown-mermaid/issues/258)