### PR TITLE
Node modules are bundled in the extensions - Update .vscodeignore to ignore the folder

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ src/
 **/*.map
 .gitignore
 tsconfig*.json
+node_modules/**


### PR DESCRIPTION
Relates to #313. I tested the build and the bundles do not require node_modules, it is vsce that bundles the folder. By adding it to .vscodeignore the folder is not included and the extension works.