### PR TITLE
Add workflow for Node.js package publishing

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://npm.pkg.github.com
       - run: npm ci
       - run: npm install -g vsce
       - run: vsce publish


### PR DESCRIPTION
This workflow runs tests and publishes a Node.js package to GitHub Packages upon release creation.