### PR TITLE
Add standalone Mermaid viewer and fullscreen overlay / 新增独立 Mermaid 查看器与全屏叠加

### DIFF
--- a/build/esbuild-webview.ts
+++ b/build/esbuild-webview.ts
@@ -4,6 +4,7 @@ import path from 'path';
 const srcDir = path.join(import.meta.dirname, '..', 'src');
 const distPreviewDir = path.join(import.meta.dirname, '..', 'dist-preview');
 const distNotebookDir = path.join(import.meta.dirname, '..', 'dist-notebook');
+const distViewerDir = path.join(import.meta.dirname, '..', 'dist-viewer');
 
 // Plugin to bundle CSS files (with @import resolution) and export as text
 const cssTextPlugin: Plugin = {
@@ -69,13 +70,23 @@ async function main() {
         format: 'esm',
     };
 
+    const viewerOptions: BuildOptions = {
+        ...sharedOptions,
+        entryPoints: {
+            'index.bundle': path.join(srcDir, 'viewer', 'index.ts'),
+        },
+        outdir: distViewerDir,
+        format: 'iife',
+    };
+
     if (isWatch) {
         const previewCtx = await esbuild.context(previewOptions);
         const notebookCtx = await esbuild.context(notebookOptions);
-        await Promise.all([previewCtx.watch(), notebookCtx.watch()]);
+        const viewerCtx = await esbuild.context(viewerOptions);
+        await Promise.all([previewCtx.watch(), notebookCtx.watch(), viewerCtx.watch()]);
         console.log('Watching for changes...');
     } else {
-        await Promise.all([build(previewOptions), build(notebookOptions)]);
+        await Promise.all([build(previewOptions), build(notebookOptions), build(viewerOptions)]);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -811,6 +811,7 @@
       "version": "1.7.23",
       "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
       "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "peer": true,
       "dependencies": {
         "@tanstack/vue-virtual": "^3.0.0-beta.60"
       },
@@ -1470,6 +1471,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1868,6 +1870,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2317,6 +2320,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.2.tgz",
       "integrity": "sha512-/eOXg2uGdMdpGlEes5Sf6zE+jUG+05f3htFNQIxLxduOH/SsaUZiPBfAwP1btVIVzsnhiNOdi+hvDRLYfMZjGw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2686,6 +2690,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3136,6 +3141,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4621,6 +4627,7 @@
       "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.2.tgz",
       "integrity": "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.1",
@@ -5119,6 +5126,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -5977,6 +5985,7 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
       "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6083,6 +6092,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6223,6 +6233,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6374,6 +6385,7 @@
       "version": "3.5.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.12.tgz",
       "integrity": "sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.12",
         "@vue/compiler-sfc": "3.5.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "engines": {
     "vscode": "^1.100.0"
   },
-  "activationEvents": [],
+  "activationEvents": [
+    "onUri"
+  ],
   "main": "./dist/index.js",
   "browser": "./dist/web/index.js",
   "categories": [

--- a/src/markdownPreview/index.ts
+++ b/src/markdownPreview/index.ts
@@ -4,8 +4,9 @@
  * This runs in the markdown preview's webview.
  */
 import mermaid, { MermaidConfig } from 'mermaid';
-import { loadExtensionConfig, registerMermaidAddons, renderMermaidBlocksInElement } from '../shared-mermaid';
-import { DiagramManager } from '../shared-mermaid/diagramManager';
+import { encodeBase64Url } from '../shared-mermaid/base64url';
+import { loadExtensionConfig, loadPreviewRuntimeData, registerMermaidAddons, renderMermaidBlocksInElement } from '../shared-mermaid';
+import { DiagramManager, FullscreenBehavior } from '../shared-mermaid/diagramManager';
 import { IDisposable } from '../shared-mermaid/disposable';
 
 let currentAbortController: AbortController | undefined;
@@ -25,6 +26,10 @@ async function init() {
 
     const extConfig = loadExtensionConfig();
     diagramManager.updateConfig(extConfig);
+    diagramManager.updateOptions({
+        fullscreenBehavior: FullscreenBehavior.Link,
+        getFullscreenLinkHref: createFullscreenLinkBuilder(extConfig),
+    });
 
     const config: MermaidConfig = {
         startOnLoad: false,
@@ -50,3 +55,36 @@ async function init() {
 
 window.addEventListener('vscode.markdown.updateContent', init);
 init();
+
+function createFullscreenLinkBuilder(config: ReturnType<typeof loadExtensionConfig>) {
+    const previewRuntime = loadPreviewRuntimeData();
+    const sourceUri = loadPreviewSourceUri();
+    if (!previewRuntime || !sourceUri) {
+        return () => undefined;
+    }
+
+    const encodedConfig = encodeBase64Url(JSON.stringify(config));
+    return (containerId: string) => {
+        const params = new URLSearchParams({
+            source: sourceUri,
+            containerId,
+            config: encodedConfig,
+        });
+        return `${previewRuntime.uriScheme}://${previewRuntime.extensionId}/open-mermaid-viewer?${params.toString()}`;
+    };
+}
+
+function loadPreviewSourceUri(): string | undefined {
+    const previewData = document.getElementById('vscode-markdown-preview-data');
+    const rawSettings = previewData?.getAttribute('data-settings');
+    if (!rawSettings) {
+        return;
+    }
+
+    try {
+        const settings = JSON.parse(rawSettings);
+        return typeof settings.source === 'string' ? settings.source : undefined;
+    } catch {
+        return;
+    }
+}

--- a/src/shared-mermaid/base64url.ts
+++ b/src/shared-mermaid/base64url.ts
@@ -1,0 +1,37 @@
+function getBase64(input: Uint8Array): string {
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(input).toString('base64');
+    }
+
+    let binary = '';
+    for (const byte of input) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary);
+}
+
+function fromBase64(base64: string): Uint8Array {
+    if (typeof Buffer !== 'undefined') {
+        return new Uint8Array(Buffer.from(base64, 'base64'));
+    }
+
+    const binary = atob(base64);
+    return Uint8Array.from(binary, char => char.charCodeAt(0));
+}
+
+export function encodeBase64Url(value: string): string {
+    const bytes = new TextEncoder().encode(value);
+    return getBase64(bytes)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
+}
+
+export function decodeBase64Url(value: string): string {
+    const base64 = value
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const bytes = fromBase64(base64);
+    return new TextDecoder().decode(bytes);
+}

--- a/src/shared-mermaid/diagramManager.ts
+++ b/src/shared-mermaid/diagramManager.ts
@@ -23,6 +23,17 @@ export interface PanZoomState {
     readonly customHeight?: number;
 }
 
+export const enum FullscreenBehavior {
+    Overlay = 'overlay',
+    Link = 'link',
+    Disabled = 'disabled',
+}
+
+export interface DiagramManagerOptions {
+    readonly fullscreenBehavior?: FullscreenBehavior;
+    readonly getFullscreenLinkHref?: (id: string) => string | undefined;
+}
+
 /**
  * Manages all DiagramElement instances within a window/document.
  */
@@ -34,9 +45,11 @@ export class DiagramManager {
     private readonly diagramStyleSheet: HTMLStyleElement;
 
     private config: MermaidExtensionConfig;
+    private options: DiagramManagerOptions;
 
-    constructor(config: MermaidExtensionConfig) {
+    constructor(config: MermaidExtensionConfig, options: DiagramManagerOptions = {}) {
         this.config = config;
+        this.options = options;
 
         this.diagramStyleSheet = document.createElement('style');
         this.diagramStyleSheet.className = 'markdown-style mermaid-diagram-styles';
@@ -46,6 +59,10 @@ export class DiagramManager {
 
     public updateConfig(config: MermaidExtensionConfig): void {
         this.config = config;
+    }
+
+    public updateOptions(options: DiagramManagerOptions): void {
+        this.options = options;
     }
 
     /**
@@ -78,7 +95,7 @@ export class DiagramManager {
 
         // Create and track instance
         const state = this.savedStates.get(id);
-        const instance = new DiagramElement(wrapper, content, this.config, state);
+        const instance = new DiagramElement(id, wrapper, content, this.config, this.options, state);
         this.instances.set(id, instance);
 
         // Initialize after DOM update
@@ -141,6 +158,7 @@ export class DiagramElement {
     private customHeight: number | undefined;
 
     private panModeButton: HTMLButtonElement | null = null;
+    private fullscreenButton: HTMLButtonElement | null = null;
     private readonly resizeHandle: HTMLElement | null = null;
     private readonly resizeObserver: ResizeObserver;
 
@@ -148,19 +166,29 @@ export class DiagramElement {
     private readonly clickDrag: ClickDragMode;
     private readonly resizable: boolean;
     private readonly maxHeight: string;
+    private readonly fullscreenBehavior: FullscreenBehavior;
+    private readonly getFullscreenLinkHref?: (id: string) => string | undefined;
 
     private readonly abortController = new AbortController();
 
+    private isFullscreenActive = false;
+    private savedContainerHeight = '';
+    private savedContainerMaxHeight = '';
+
     constructor(
+        private readonly id: string,
         private readonly container: HTMLElement,
         private readonly content: HTMLElement,
         config: MermaidExtensionConfig,
+        options: DiagramManagerOptions,
         initialState?: PanZoomState
     ) {
         this.showControls = config.showControls;
         this.clickDrag = config.clickDrag;
         this.resizable = config.resizable;
         this.maxHeight = config.maxHeight;
+        this.fullscreenBehavior = options.fullscreenBehavior ?? FullscreenBehavior.Overlay;
+        this.getFullscreenLinkHref = options.getFullscreenLinkHref;
 
         // Restore state if provided
         if (initialState) {
@@ -255,6 +283,7 @@ export class DiagramElement {
             <button class="zoom-in-btn" title="Zoom In"><span class="codicon codicon-zoom-in"></span></button>
             <button class="zoom-reset-btn" title="Reset Zoom"><span class="codicon codicon-screen-normal"></span></button>
         `;
+        controls.addEventListener('mousedown', e => e.stopPropagation(), { signal });
 
         this.panModeButton = controls.querySelector('.pan-mode-btn');
         this.panModeButton?.addEventListener('click', e => {
@@ -277,6 +306,36 @@ export class DiagramElement {
             e.stopPropagation();
             this.reset();
         }, { signal });
+
+        if (this.fullscreenBehavior === FullscreenBehavior.Overlay) {
+            this.fullscreenButton = document.createElement('button');
+            this.fullscreenButton.className = 'fullscreen-btn';
+            this.fullscreenButton.title = 'Fullscreen';
+            this.fullscreenButton.innerHTML = '<span class="codicon codicon-screen-full"></span>';
+            this.fullscreenButton.addEventListener('click', e => {
+                e.preventDefault();
+                e.stopPropagation();
+                this.toggleFullscreen();
+            }, { signal });
+            controls.appendChild(this.fullscreenButton);
+
+            window.addEventListener('keydown', e => {
+                if (e.key === 'Escape' && this.isFullscreenActive) {
+                    this.exitFullscreen();
+                }
+            }, { signal });
+        } else if (this.fullscreenBehavior === FullscreenBehavior.Link) {
+            const href = this.getFullscreenLinkHref?.(this.id);
+            if (href) {
+                const fullscreenLink = document.createElement('a');
+                fullscreenLink.className = 'fullscreen-btn';
+                fullscreenLink.href = href;
+                fullscreenLink.title = 'Open in New Window';
+                fullscreenLink.setAttribute('aria-label', 'Open in New Window');
+                fullscreenLink.innerHTML = '<span class="codicon codicon-screen-full"></span>';
+                controls.appendChild(fullscreenLink);
+            }
+        }
 
         this.container.appendChild(controls);
     }
@@ -541,6 +600,52 @@ export class DiagramElement {
         };
 
         this.applyTransform();
+    }
+
+    private toggleFullscreen(): void {
+        if (this.isFullscreenActive) {
+            this.exitFullscreen();
+        } else {
+            this.enterFullscreen();
+        }
+    }
+
+    private enterFullscreen(): void {
+        this.isFullscreenActive = true;
+
+        // Save current inline styles before fullscreen overrides them
+        this.savedContainerHeight = this.container.style.height;
+        this.savedContainerMaxHeight = this.container.style.maxHeight;
+
+        this.container.classList.add('mermaid-fullscreen');
+
+        // Update button icon
+        if (this.fullscreenButton) {
+            const icon = this.fullscreenButton.querySelector('.codicon');
+            icon?.classList.replace('codicon-screen-full', 'codicon-screen-normal');
+            this.fullscreenButton.title = 'Exit Fullscreen';
+        }
+
+        this.container.focus();
+        this.centerContent();
+    }
+
+    private exitFullscreen(): void {
+        this.isFullscreenActive = false;
+        this.container.classList.remove('mermaid-fullscreen');
+
+        // Restore inline styles
+        this.container.style.height = this.savedContainerHeight;
+        this.container.style.maxHeight = this.savedContainerMaxHeight;
+
+        // Update button icon
+        if (this.fullscreenButton) {
+            const icon = this.fullscreenButton.querySelector('.codicon');
+            icon?.classList.replace('codicon-screen-normal', 'codicon-screen-full');
+            this.fullscreenButton.title = 'Fullscreen';
+        }
+
+        this.centerContent();
     }
 
     public reset(): void {

--- a/src/shared-mermaid/diagramStyles.css
+++ b/src/shared-mermaid/diagramStyles.css
@@ -25,7 +25,7 @@
     opacity: 1;
 }
 
-.mermaid-zoom-controls button {
+.mermaid-zoom-controls :is(button, a) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -36,13 +36,14 @@
     border: none;
     border-radius: 4px;
     cursor: pointer;
+    text-decoration: none;
 }
 
-.mermaid-zoom-controls button:hover {
+.mermaid-zoom-controls :is(button, a):hover {
     background: var(--vscode-toolbar-hoverBackground);
 }
 
-.mermaid-zoom-controls button.active {
+.mermaid-zoom-controls :is(button, a).active {
     background: var(--vscode-toolbar-activeBackground);
     color: var(--vscode-focusBorder);
 }
@@ -96,4 +97,26 @@
 .mermaid-resize-handle:hover::after {
     opacity: 1;
     transition-delay: 0.3s;
+}
+
+/* Fullscreen overlay */
+.mermaid-wrapper.mermaid-fullscreen {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;
+    max-height: none !important;
+    z-index: 9999 !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    border-color: transparent !important;
+    background: var(--vscode-editor-background) !important;
+}
+
+.mermaid-wrapper.mermaid-fullscreen .mermaid-zoom-controls {
+    top: 12px;
+    right: 12px;
 }

--- a/src/shared-mermaid/index.ts
+++ b/src/shared-mermaid/index.ts
@@ -5,6 +5,12 @@ import mermaid, { MermaidConfig } from 'mermaid';
 import { iconPacks } from './iconPackConfig';
 import { ClickDragMode, ShowControlsMode } from './config';
 import { MermaidExtensionConfig } from './config';
+import { generateContentId, hashString } from './markdownBlocks';
+
+interface PreviewRuntimeData {
+    readonly extensionId: string;
+    readonly uriScheme: string;
+}
 
 function renderMermaidElement(
     mermaidContainer: HTMLElement,
@@ -134,32 +140,21 @@ export function loadMermaidConfig(): MermaidConfig {
     };
 }
 
-/**
- * Generate a simple hash from a string for content-based IDs.
- * Uses a fast non-cryptographic hash suitable for deduplication.
- */
-function hashString(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash; // Convert to 32bit integer
-    }
-    // Convert to hex and ensure positive
-    return (hash >>> 0).toString(16).padStart(8, '0');
-}
-
-function generateContentId(source: string, usedIds: Set<string>): string {
-    const hash = hashString(source);
-    let id = `mermaid-${hash}`;
-    let counter = 0;
-
-    // Handle collisions by appending a counter
-    while (usedIds.has(id)) {
-        counter++;
-        id = `mermaid-${hash}-${counter}`;
+export function loadPreviewRuntimeData(): PreviewRuntimeData | undefined {
+    const configSpan = document.getElementById('markdown-mermaid');
+    const runtimeAttr = configSpan?.dataset.previewRuntime;
+    if (!runtimeAttr) {
+        return;
     }
 
-    usedIds.add(id);
-    return id;
+    try {
+        const runtime = JSON.parse(runtimeAttr);
+        if (runtime && typeof runtime.extensionId === 'string' && typeof runtime.uriScheme === 'string') {
+            return runtime;
+        }
+    } catch {
+        // Ignore malformed runtime metadata and fall back to disabling pop-out links.
+    }
 }
+
+export { extractMermaidBlocks, generateContentId, hashString } from './markdownBlocks';

--- a/src/shared-mermaid/markdownBlocks.ts
+++ b/src/shared-mermaid/markdownBlocks.ts
@@ -1,0 +1,120 @@
+export interface MermaidBlockMatch {
+    readonly containerId: string;
+    readonly contentHash: string;
+    readonly source: string;
+}
+
+export function extractMermaidBlocks(markdown: string, languageIds: readonly string[]): MermaidBlockMatch[] {
+    const normalizedLanguageIds = new Set(languageIds.map(id => id.toLowerCase()));
+    const matches: MermaidBlockMatch[] = [];
+    const usedIds = new Set<string>();
+    const lines = markdown.split(/\r?\n/);
+
+    for (let i = 0; i < lines.length; i++) {
+        const fenceMatch = parseMermaidFence(lines, i, normalizedLanguageIds);
+        if (fenceMatch) {
+            if (fenceMatch.source) {
+                matches.push({
+                    source: fenceMatch.source,
+                    contentHash: hashString(fenceMatch.source),
+                    containerId: generateContentId(fenceMatch.source, usedIds),
+                });
+            }
+            i = fenceMatch.endLine;
+            continue;
+        }
+
+        const containerMatch = parseMermaidContainer(lines, i);
+        if (containerMatch) {
+            if (containerMatch.source) {
+                matches.push({
+                    source: containerMatch.source,
+                    contentHash: hashString(containerMatch.source),
+                    containerId: generateContentId(containerMatch.source, usedIds),
+                });
+            }
+            i = containerMatch.endLine;
+        }
+    }
+
+    return matches;
+}
+
+export function hashString(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash;
+    }
+
+    return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function generateContentId(source: string, usedIds: Set<string>): string {
+    const hash = hashString(source);
+    let id = `mermaid-${hash}`;
+    let counter = 0;
+
+    while (usedIds.has(id)) {
+        counter++;
+        id = `mermaid-${hash}-${counter}`;
+    }
+
+    usedIds.add(id);
+    return id;
+}
+
+function parseMermaidFence(lines: readonly string[], startLine: number, languageIds: ReadonlySet<string>) {
+    const line = lines[startLine];
+    const match = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(line);
+    if (!match) {
+        return;
+    }
+
+    const [, indent, fence, info] = match;
+    const languageId = info.trim().split(/\s+/)[0]?.toLowerCase();
+    if (!languageId || !languageIds.has(languageId)) {
+        return;
+    }
+
+    let endLine = startLine + 1;
+    while (endLine < lines.length) {
+        const closingLine = lines[endLine];
+        const closingMatch = /^(\s*)(`{3,}|~{3,})\s*$/.exec(closingLine);
+        if (closingMatch && closingMatch[2][0] === fence[0] && closingMatch[2].length >= fence.length && closingMatch[1].length <= indent.length + 3) {
+            break;
+        }
+        endLine++;
+    }
+
+    const source = lines.slice(startLine + 1, endLine).join('\n').trim();
+    return { source, endLine };
+}
+
+function parseMermaidContainer(lines: readonly string[], startLine: number) {
+    const line = lines[startLine];
+    const match = /^(\s*)(:{3,})(.*)$/.exec(line);
+    if (!match) {
+        return;
+    }
+
+    const [, indent, marker, info] = match;
+    const languageId = info.trim().split(/\s+/)[0]?.toLowerCase();
+    if (languageId !== 'mermaid') {
+        return;
+    }
+
+    let endLine = startLine + 1;
+    while (endLine < lines.length) {
+        const closingLine = lines[endLine];
+        const closingMatch = /^(\s*)(:{3,})\s*$/.exec(closingLine);
+        if (closingMatch && closingMatch[2].length >= marker.length && closingMatch[1].length <= indent.length + 3) {
+            break;
+        }
+        endLine++;
+    }
+
+    const source = lines.slice(startLine + 1, endLine).join('\n').trim();
+    return { source, endLine };
+}

--- a/src/viewer/index.ts
+++ b/src/viewer/index.ts
@@ -1,0 +1,56 @@
+import mermaid, { MermaidConfig } from 'mermaid';
+import { loadExtensionConfig, registerMermaidAddons, renderMermaidBlocksInElement } from '../shared-mermaid';
+import { ClickDragMode } from '../shared-mermaid/config';
+import { DiagramManager, FullscreenBehavior } from '../shared-mermaid/diagramManager';
+import { IDisposable } from '../shared-mermaid/disposable';
+
+let currentAbortController: AbortController | undefined;
+let currentDisposables: IDisposable[] = [];
+const diagramManager = new DiagramManager(loadExtensionConfig(), {
+    fullscreenBehavior: FullscreenBehavior.Disabled,
+});
+
+async function init() {
+    for (const disposable of currentDisposables) {
+        disposable.dispose();
+    }
+    currentDisposables = [];
+
+    currentAbortController?.abort();
+    currentAbortController = new AbortController();
+    const signal = currentAbortController.signal;
+
+    const extConfig = loadExtensionConfig();
+    const viewerConfig = {
+        ...extConfig,
+        // Auxiliary windows on Windows/VS Code steal focus on bare Alt,
+        // so viewer pop-outs should not require Alt for panning.
+        clickDrag: extConfig.clickDrag === ClickDragMode.Alt ? ClickDragMode.Always : extConfig.clickDrag,
+        // A dedicated viewer should size to the diagram by default instead of
+        // inheriting preview-specific max-height constraints.
+        maxHeight: '',
+    };
+    diagramManager.updateConfig(viewerConfig);
+
+    const config: MermaidConfig = {
+        startOnLoad: false,
+        maxTextSize: viewerConfig.maxTextSize,
+        theme: (document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast')
+            ? viewerConfig.darkModeTheme
+            : viewerConfig.lightModeTheme) as MermaidConfig['theme'],
+    };
+
+    mermaid.initialize(config);
+    await registerMermaidAddons();
+
+    const activeIds = new Set<string>();
+    await renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {
+        mermaidContainer.innerHTML = content;
+        activeIds.add(mermaidContainer.id);
+        currentDisposables.push(diagramManager.setup(mermaidContainer.id, mermaidContainer));
+    }, signal);
+
+    diagramManager.retainStates(activeIds);
+}
+
+init();

--- a/src/vscode-extension/config.ts
+++ b/src/vscode-extension/config.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { ClickDragMode, ShowControlsMode } from '../shared-mermaid/config';
 
 export const configSection = 'markdown-mermaid';
+export const previewRuntimeAttribute = 'data-preview-runtime';
 
 const defaultMermaidTheme = 'default';
 const validMermaidThemes = [
@@ -17,22 +18,30 @@ function sanitizeMermaidTheme(theme: string | undefined) {
     return typeof theme === 'string' && validMermaidThemes.includes(theme) ? theme : defaultMermaidTheme;
 }
 
-export function injectMermaidConfig(md: MarkdownIt) {
+export function getConfiguredLanguageIds(config: vscode.WorkspaceConfiguration): readonly string[] {
+    return config.get<string[]>('languages', ['mermaid']);
+}
+
+export function getMermaidConfigData(config: vscode.WorkspaceConfiguration) {
+    return {
+        darkModeTheme: sanitizeMermaidTheme(config.get('darkModeTheme')),
+        lightModeTheme: sanitizeMermaidTheme(config.get('lightModeTheme')),
+        maxTextSize: config.get('maxTextSize') as number,
+        clickDrag: config.get<ClickDragMode>('mouseNavigation.enabled', ClickDragMode.Alt),
+        showControls: config.get<ShowControlsMode>('controls.show', ShowControlsMode.OnHoverOrFocus),
+        resizable: config.get<boolean>('resizable', true),
+        maxHeight: config.get<string>('maxHeight', ''),
+    };
+}
+
+export function injectMermaidConfig(md: MarkdownIt, runtime: { extensionId: string; uriScheme: string }) {
     const render = md.renderer.render;
     md.renderer.render = function (...args) {
         const config = vscode.workspace.getConfiguration(configSection);
-        const configData = {
-            darkModeTheme: sanitizeMermaidTheme(config.get('darkModeTheme')),
-            lightModeTheme: sanitizeMermaidTheme(config.get('lightModeTheme')),
-            maxTextSize: config.get('maxTextSize') as number,
-            clickDrag: config.get<ClickDragMode>('mouseNavigation.enabled', ClickDragMode.Alt),
-            showControls: config.get<ShowControlsMode>('controls.show', ShowControlsMode.OnHoverOrFocus),
-            resizable: config.get<boolean>('resizable', true),
-            maxHeight: config.get<string>('maxHeight', ''),
-        };
-
+        const configData = getMermaidConfigData(config);
         const escapedConfig = escapeHtmlAttribute(JSON.stringify(configData));
-        return `<span id="${configSection}" aria-hidden="true" data-config="${escapedConfig}"></span>
+        const escapedRuntime = escapeHtmlAttribute(JSON.stringify(runtime));
+        return `<span id="${configSection}" aria-hidden="true" data-config="${escapedConfig}" ${previewRuntimeAttribute}="${escapedRuntime}"></span>
                 ${render.apply(md.renderer, args)}`;
     };
     return md;

--- a/src/vscode-extension/index.ts
+++ b/src/vscode-extension/index.ts
@@ -1,26 +1,177 @@
 import type MarkdownIt from 'markdown-it';
 import * as vscode from 'vscode';
+import { decodeBase64Url } from '../shared-mermaid/base64url';
+import { MermaidExtensionConfig } from '../shared-mermaid/config';
+import { extractMermaidBlocks } from '../shared-mermaid';
 import { extendMarkdownItWithMermaid } from '../shared-md-mermaid';
-import { configSection, injectMermaidConfig } from './config';
+import { configSection, getConfiguredLanguageIds, getMermaidConfigData, injectMermaidConfig } from './config';
+
+const openMermaidViewerCommand = 'markdown-mermaid.openMermaidViewer';
+const viewerViewType = 'markdown-mermaid.viewer';
+const openMermaidViewerPath = '/open-mermaid-viewer';
+
+interface MermaidViewerRequest {
+    readonly source: vscode.Uri;
+    readonly containerId: string;
+    readonly config?: Partial<MermaidExtensionConfig>;
+}
 
 export function activate(ctx: vscode.ExtensionContext) {
-    // Reload the previews when the configuration changes. This is needed so that the markdown plugin can see the
-    // latest configuration values
     ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration(configSection) || e.affectsConfiguration('workbench.colorTheme')) {
             vscode.commands.executeCommand('markdown.preview.refresh');
         }
     }));
 
+    ctx.subscriptions.push(vscode.commands.registerCommand(openMermaidViewerCommand, async (request: MermaidViewerRequest) => {
+        await openMermaidViewer(ctx, request);
+    }));
+
+    ctx.subscriptions.push(vscode.window.registerUriHandler({
+        handleUri: async (uri: vscode.Uri) => {
+            const request = parseMermaidViewerUri(uri, ctx.extension.id);
+            if (!request) {
+                return;
+            }
+
+            await vscode.commands.executeCommand(openMermaidViewerCommand, request);
+        }
+    }));
+
     return {
         extendMarkdownIt(md: MarkdownIt) {
             extendMarkdownItWithMermaid(md, {
-                languageIds: () => {
-                    return vscode.workspace.getConfiguration(configSection).get<string[]>('languages', ['mermaid']);
-                }
+                languageIds: () => getConfiguredLanguageIds(vscode.workspace.getConfiguration(configSection)),
             });
-            md.use(injectMermaidConfig);
+            injectMermaidConfig(md, {
+                extensionId: ctx.extension.id,
+                uriScheme: vscode.env.uriScheme,
+            });
             return md;
         }
     };
+}
+
+async function openMermaidViewer(ctx: vscode.ExtensionContext, request: MermaidViewerRequest): Promise<void> {
+    const document = await vscode.workspace.openTextDocument(request.source);
+    const workspaceConfig = vscode.workspace.getConfiguration(configSection, document.uri);
+    const config = {
+        ...getMermaidConfigData(workspaceConfig),
+        ...request.config,
+    } as MermaidExtensionConfig;
+    const mermaidBlock = extractMermaidBlocks(document.getText(), getConfiguredLanguageIds(workspaceConfig))
+        .find(block => block.containerId === request.containerId);
+
+    if (!mermaidBlock) {
+        vscode.window.showWarningMessage('Could not find the requested Mermaid diagram in the current Markdown document.');
+        return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(viewerViewType, 'Mermaid Viewer', vscode.ViewColumn.Active, {
+        enableScripts: true,
+        localResourceRoots: [ctx.extensionUri],
+    });
+    panel.webview.html = getViewerHtml(ctx, panel.webview, mermaidBlock.source, config);
+    panel.reveal(vscode.ViewColumn.Active);
+
+    try {
+        await vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow');
+    } catch {
+        vscode.window.setStatusBarMessage('Markdown Mermaid: opened viewer in the current window because moving editors to a new window is unavailable here.', 5000);
+    }
+}
+
+function parseMermaidViewerUri(uri: vscode.Uri, extensionId: string): MermaidViewerRequest | undefined {
+    if (uri.authority !== extensionId || uri.path !== openMermaidViewerPath) {
+        return;
+    }
+
+    const params = new URLSearchParams(uri.query);
+    const source = params.get('source');
+    const containerId = params.get('containerId');
+    if (!source || !containerId) {
+        return;
+    }
+
+    try {
+        return {
+            source: vscode.Uri.parse(source, true),
+            containerId,
+            config: parseViewerConfig(params.get('config')),
+        };
+    } catch {
+        vscode.window.showWarningMessage('Could not open Mermaid viewer from the current preview link.');
+        return;
+    }
+}
+
+function parseViewerConfig(encodedConfig: string | null): Partial<MermaidExtensionConfig> | undefined {
+    if (!encodedConfig) {
+        return;
+    }
+
+    try {
+        const parsed = JSON.parse(decodeBase64Url(encodedConfig));
+        return parsed && typeof parsed === 'object' ? parsed as Partial<MermaidExtensionConfig> : undefined;
+    } catch {
+        return;
+    }
+}
+
+function getViewerHtml(
+    ctx: vscode.ExtensionContext,
+    webview: vscode.Webview,
+    source: string,
+    config: MermaidExtensionConfig
+): string {
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(ctx.extensionUri, 'dist-viewer', 'index.bundle.js'));
+    const escapedConfig = escapeHtmlAttribute(JSON.stringify(config));
+    const escapedSource = escapeHtml(source);
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline'; font-src ${webview.cspSource} data:; script-src ${webview.cspSource};">
+    <title>Mermaid Viewer</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: var(--vscode-editor-background);
+        }
+
+        body {
+            min-height: 100vh;
+            box-sizing: border-box;
+            overflow: auto;
+            padding: 12px;
+        }
+
+        .mermaid-viewer-root {
+            display: block;
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
+    <span id="${configSection}" aria-hidden="true" data-config="${escapedConfig}"></span>
+    <div class="mermaid-viewer-root">
+        <div class="mermaid">${escapedSource}</div>
+    </div>
+    <script src="${scriptUri}"></script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function escapeHtmlAttribute(value: string): string {
+    return escapeHtml(value).replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
 ## Summary

  - New standalone Mermaid viewer opens diagrams in a separate window via URI handler
  - Fullscreen overlay mode in markdown preview (press Escape to exit)
  - Refactor content ID generation into shared `markdownBlocks.ts` module
  - Add `base64url.ts` utility and viewer webview entry (`src/viewer/`)

  ## 摘要

  - 新增独立 Mermaid 查看器，通过 URI handler 在新窗口打开图表
  - Markdown 预览中新增全屏叠加模式（按 Escape 退出）
  - 将内容 ID 生成重构到共享模块 `markdownBlocks.ts`
  - 新增 `base64url.ts` 工具和 viewer webview 入口（`src/viewer/`）

  ## Test plan

  - [ ] Verify fullscreen overlay in markdown preview
  - [ ] Verify "Open in New Window" link works
  - [ ] Verify Escape exits fullscreen
  - [ ] `npm run build-webview` produces viewer bundle
  - [ ] `npm run lint` passes
 ## image
<img width="1653" height="900" alt="image" src="https://github.com/user-attachments/assets/decedd77-3481-4a4e-a8f6-448b8b50cadc" />
<img width="1653" height="900" alt="image" src="https://github.com/user-attachments/assets/95eb308b-d0ea-44c8-a569-c4a6b6f0b9ae" />
