### PR TITLE
Fix notebook renderer breaking with mermaid ≥ 11.17.0 (AMD define vs UMD fastdom)

### DIFF
--- a/build/esbuild-webview.ts
+++ b/build/esbuild-webview.ts
@@ -62,6 +62,10 @@ async function main() {
 
     const notebookOptions: BuildOptions = {
         ...sharedOptions,
+        // Notebook webviews have VS Code's AMD loader global (`define`), which makes
+        // fastdom's UMD wrapper take the AMD branch and never assign module.exports.
+        // Shadow it so CJS interop works.
+        banner: { js: 'var define = undefined;' },
         entryPoints: {
             'index.bundle': path.join(srcDir, 'notebook', 'index.ts'),
         },


### PR DESCRIPTION
## Problem

Mermaid blocks in **notebook markdown cells** render as plain code (no diagram) when the extension is built against **mermaid ≥ 11.17.0**. Markdown preview is unaffected, and notebooks worked fine up through mermaid 11.16.x.

The notebook webview console shows:

```
TypeError: pm0.default.extend is not a function
    at index.bundle.js:454:102
```

The renderer module throws during load, `activate()` never completes, `extendMarkdownIt` is never called, and markdown-it falls back to rendering the fence as a code block. KaTeX and other extending renderers keep working, which makes this look like a mermaid-specific failure.

## Root cause

1. **mermaid 11.17.0 added a dependency on `fastdom`** (used by the new text-measurement utility that powers `preprocessMarkdown` / `splitTextToChars` etc. — `dist/chunks/.../chunk-*.mjs`). Since `package.json` allows `mermaid: ^11.12.2`, any fresh build pulls it in.
2. fastdom ships a **UMD wrapper that checks AMD first**:

   ```js
   var c = r.fastdom = r.fastdom || new s;
   typeof define == "function" ? define(function(){ return c })
       : typeof module == "object" && (module.exports = c);
   ```
3. **VS Code notebook webviews expose an AMD `define` global** (the workbench's module loader). So inside the notebook webview, fastdom takes the AMD branch, `module.exports` stays an empty object, and esbuild's `__toESM` interop produces `{ default: {} }`.
4. The text-measurement module then does `fastdom.default.extend({ raf })` at module scope → `{}.extend` → `TypeError`, killing the whole renderer module before `activate` runs.

Markdown preview survives because its webview context has no AMD `define`.

## Repro

```bash
npm install mermaid@^11.17.0
npm run vscode:prepublish
```

Install the vsix, open an `.ipynb`, add a markdown cell:

``````markdown
```mermaid
flowchart LR
  A --> B
```
``````

Renders as a code block; **Developer: Open Webview Developer Tools** shows the `TypeError` above.

I also reproduced it outside VS Code: load `dist-notebook/index.bundle.js` as an ES module in a plain browser page (works), then set `window.define = function(){}; define.amd = {};` before import → fails with the identical error at the identical location.

## Fix

Shadow `define` at the top of the notebook bundle so UMD wrappers always take the CommonJS branch:

```ts
banner: { js: 'var define = undefined;' },
```

Verified after the fix, with `define.amd` present: flowchart renders, and newer diagram types from 11.17 (e.g. `venn-beta`) render too.

## Note

This currently doesn't reproduce from a lockfile build (pinned at mermaid 11.12.2) — it triggers the moment the lockfile moves to ≥ 11.17.0, so this is a preemptive fix for the next mermaid bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)